### PR TITLE
Provide connection label

### DIFF
--- a/src/Osma.Mobile.App/ViewModels/Connections/AcceptInviteViewModel.cs
+++ b/src/Osma.Mobile.App/ViewModels/Connections/AcceptInviteViewModel.cs
@@ -63,6 +63,7 @@ namespace Osma.Mobile.App.ViewModels.Connections
             try
             {
                 var (msg, rec) = await _connectionService.CreateRequestAsync(context, _invite);
+                msg.Label = "OSMA";
                 await _messageService.SendAsync(context.Wallet, msg, rec);
 
                 _eventAggregator.Publish(new ApplicationEvent() { Type = ApplicationEventType.ConnectionsUpdated });


### PR DESCRIPTION
This PR just adds a label to the connection request. The label is mandatory to connect with acapy agents with the toolbox agent (and probably others) otherwise the acapy agent fails with a validation error "Label must not be null" as mentioned in #13 