### PR TITLE
Request legacy storage in Android 10 (API Level 29)

### DIFF
--- a/src/Osma.Mobile.App.Android/Properties/AndroidManifest.xml
+++ b/src/Osma.Mobile.App.Android/Properties/AndroidManifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="0.1.0" package="com.osma" android:installLocation="internalOnly">
-	<uses-sdk android:minSdkVersion="25" android:targetSdkVersion="28" />
-	<application android:label="Osma"></application>
+	<uses-sdk android:minSdkVersion="25" android:targetSdkVersion="29" />
+	<application android:requestLegacyExternalStorage="true" android:label="Osma"></application>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.CAMERA" />


### PR DESCRIPTION
Support the targeting of Android 29 without explicit support scoped storage. 

**Android Docs:**
https://developer.android.com/about/versions/11/privacy/storage